### PR TITLE
Add EXPOSE, ENV with app environment variables to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,4 +14,8 @@ COPY --from=builder /app/backend/node_modules node_modules
 COPY --from=builder /app/backend/static static
 COPY --from=builder /app/backend/.yarn .yarn
 RUN corepack enable && corepack install
+
 ENTRYPOINT ["yarn", "node", "dist/src/main.js"]
+ENV APP_PORT=3000
+ENV NODE_ENV=production
+EXPOSE 3000

--- a/backend/.env
+++ b/backend/.env
@@ -1,2 +1,5 @@
 # This is an example .env file! Local development secrets must go in .env.local
-POSTGRES_URL=pg://backend:supersecretpassword@localhost:5432/database
+# Port for web application to serve static files and endpoints at
+APP_PORT=3000
+# App environment, should be set to 'production' when in production
+NODE_ENV=dev

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -1,10 +1,12 @@
+import { ConfigService } from "@nestjs/config";
 import { NestFactory } from "@nestjs/core";
 
 import { AppModule } from "./app.module.js";
 
 async function bootstrap() {
 	const app = await NestFactory.create(AppModule);
-	await app.listen(process.env.PORT ?? 3000);
+	const port = app.get(ConfigService).get<string>("APP_PORT");
+	await app.listen(+(port ?? 3000));
 }
 
 try {


### PR DESCRIPTION
This PR adds environment variables NODE_ENV=production and APP_PORT=3000 to Dockerfile, as well as takes APP_PORT from ConfigService in bootstrap.