### PR TITLE
Remove console.log from PreferencesController

### DIFF
--- a/backend/src/preferences/preferences.controller.ts
+++ b/backend/src/preferences/preferences.controller.ts
@@ -25,7 +25,6 @@ export class PreferencesController {
 		}
 
 		const preferences = await this.preferences.getPreferences();
-		console.log(dto);
 		await this.preferences.setPreferences({ ...preferences, ...dto });
 	}
 }


### PR DESCRIPTION
This PR removes accidental `console.log` leftover from PreferencesController.